### PR TITLE
Update Kinematics.cpp

### DIFF
--- a/Kinematics.cpp
+++ b/Kinematics.cpp
@@ -30,7 +30,7 @@
 
 Kinematics::Kinematics(int motor_max_rpm, float wheel_diameter, float fr_wheels_dist, float lr_wheels_dist, int pwm_bits):
   wheel_diameter_(wheel_diameter),
-  circumference_(PI * wheel_diameter_),
+  circumference_(PI * wheel_diameter),
   max_rpm_(motor_max_rpm),
   fr_wheels_dist_(fr_wheels_dist),
   lr_wheels_dist_(lr_wheels_dist),


### PR DESCRIPTION
Fixed bug where circumference_ is always 0.

If you run the example kinematics.ino you will notice that all of the output is 0. That's because the circumference was being calculated before the wheel diameter was set. This fixes that issue.